### PR TITLE
Add Japanese, Korean to supported languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Showcasing the languages supported by Mapbox Streets.
 - [English](https://mapbox.github.io/mapbox-gl-language/examples/en.html)
 - [French](https://mapbox.github.io/mapbox-gl-language/examples/fr.html)
 - [German](https://mapbox.github.io/mapbox-gl-language/examples/de.html)
+- [Japanese](https://mapbox.github.io/mapbox-gl-language/examples/ja.html)
+- [Korean](https://mapbox.github.io/mapbox-gl-language/examples/ko.html)
 - [Portuguese](https://mapbox.github.io/mapbox-gl-language/examples/pt.html)
 - [Russian](https://mapbox.github.io/mapbox-gl-language/examples/ru.html)
 - [Spanish](https://mapbox.github.io/mapbox-gl-language/examples/es.html)

--- a/README.md
+++ b/README.md
@@ -103,14 +103,14 @@ Create a minified standalone build.
 Showcasing the languages supported by Mapbox Streets.
 
 - [Your Browser language](https://mapbox.github.io/mapbox-gl-language/examples/browser.html)
-- [English](https://mapbox.github.io/mapbox-gl-language/examples/en.html)
 - [Arabic](https://mapbox.github.io/mapbox-gl-language/examples/ar.html)
-- [French](https://mapbox.github.io/mapbox-gl-language/examples/fr.html)
-- [Portuguese](https://mapbox.github.io/mapbox-gl-language/examples/pt.html)
-- [German](https://mapbox.github.io/mapbox-gl-language/examples/de.html)
-- [Spanish](https://mapbox.github.io/mapbox-gl-language/examples/es.html)
-- [Russian](https://mapbox.github.io/mapbox-gl-language/examples/ru.html)
 - [Chinese](https://mapbox.github.io/mapbox-gl-language/examples/zh.html)
+- [English](https://mapbox.github.io/mapbox-gl-language/examples/en.html)
+- [French](https://mapbox.github.io/mapbox-gl-language/examples/fr.html)
+- [German](https://mapbox.github.io/mapbox-gl-language/examples/de.html)
+- [Portuguese](https://mapbox.github.io/mapbox-gl-language/examples/pt.html)
+- [Russian](https://mapbox.github.io/mapbox-gl-language/examples/ru.html)
+- [Spanish](https://mapbox.github.io/mapbox-gl-language/examples/es.html)
 
 ## Supported Styles
 

--- a/examples/ja.html
+++ b/examples/ja.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8' />
+    <title>Mapbox GL Language</title>
+    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.36.0/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.36.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='../index.js'></script>
+    <style>
+        body { margin:0; padding:0; }
+        #map { position:absolute; top:0; bottom:0; width:100%; }
+    </style>
+</head>
+<body>
+
+<div id='map'></div>
+<script>
+mapboxgl.accessToken = 'pk.eyJ1IjoibHVrYXNtYXJ0aW5lbGxpIiwiYSI6ImNpem85dmhwazAyajIyd284dGxhN2VxYnYifQ.HQCmyhEXZUTz3S98FMrVAQ';
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/streets-v10',
+    center: [-98, 38.88],
+    minZoom: 2,
+    zoom: 3
+});
+mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.1.0/mapbox-gl-rtl-text.js');
+map.addControl(new MapboxLanguage({
+  defaultLanguage: 'ja'
+}));
+</script>
+
+</body>
+</html>

--- a/examples/ko.html
+++ b/examples/ko.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8' />
+    <title>Mapbox GL Language</title>
+    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.36.0/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.36.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='../index.js'></script>
+    <style>
+        body { margin:0; padding:0; }
+        #map { position:absolute; top:0; bottom:0; width:100%; }
+    </style>
+</head>
+<body>
+
+<div id='map'></div>
+<script>
+mapboxgl.accessToken = 'pk.eyJ1IjoibHVrYXNtYXJ0aW5lbGxpIiwiYSI6ImNpem85dmhwazAyajIyd284dGxhN2VxYnYifQ.HQCmyhEXZUTz3S98FMrVAQ';
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/streets-v10',
+    center: [-98, 38.88],
+    minZoom: 2,
+    zoom: 3
+});
+mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.1.0/mapbox-gl-rtl-text.js');
+map.addControl(new MapboxLanguage({
+  defaultLanguage: 'ko'
+}));
+</script>
+
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function MapboxLanguage(options) {
     }
   };
   this._excludedLayerIds = options.excludedLayerIds || [];
-  this.supportedLanguages = options.supportedLanguages || ['ar', 'en', 'es', 'fr', 'de', 'pt', 'ru', 'zh'];
+  this.supportedLanguages = options.supportedLanguages || ['ar', 'en', 'es', 'fr', 'de', 'ja', 'ko', 'pt', 'ru', 'zh'];
 }
 
 function standardSpacing(style) {

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function MapboxLanguage(options) {
     }
   };
   this._excludedLayerIds = options.excludedLayerIds || [];
-  this.supportedLanguages = options.supportedLanguages || ['en', 'es', 'fr', 'de', 'ru', 'zh', 'ar', 'pt'];
+  this.supportedLanguages = options.supportedLanguages || ['ar', 'en', 'es', 'fr', 'de', 'pt', 'ru', 'zh'];
 }
 
 function standardSpacing(style) {


### PR DESCRIPTION
Added Japanese and Korean to the list of languages for which the Mapbox Streets source has dedicated name fields.

Fixes #21.

/cc @lukasmartinelli