### PR TITLE
Simplified Chinese

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Showcasing the languages supported by Mapbox Streets.
 
 - [Your Browser language](https://mapbox.github.io/mapbox-gl-language/examples/browser.html)
 - [Arabic](https://mapbox.github.io/mapbox-gl-language/examples/ar.html)
-- [Chinese](https://mapbox.github.io/mapbox-gl-language/examples/zh.html)
+- [Chinese](https://mapbox.github.io/mapbox-gl-language/examples/zh.html) ([Simplified](https://mapbox.github.io/mapbox-gl-language/examples/zh-Hans.html))
 - [English](https://mapbox.github.io/mapbox-gl-language/examples/en.html)
 - [French](https://mapbox.github.io/mapbox-gl-language/examples/fr.html)
 - [German](https://mapbox.github.io/mapbox-gl-language/examples/de.html)

--- a/examples/zh-Hans.html
+++ b/examples/zh-Hans.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8' />
+    <title>Mapbox GL Language</title>
+    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.36.0/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.36.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='../index.js'></script>
+    <style>
+        body { margin:0; padding:0; }
+        #map { position:absolute; top:0; bottom:0; width:100%; }
+    </style>
+</head>
+<body>
+
+<div id='map'></div>
+<script>
+mapboxgl.accessToken = 'pk.eyJ1IjoibHVrYXNtYXJ0aW5lbGxpIiwiYSI6ImNpem85dmhwazAyajIyd284dGxhN2VxYnYifQ.HQCmyhEXZUTz3S98FMrVAQ';
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/streets-v10',
+    center: [-98, 38.88],
+    minZoom: 2,
+    zoom: 3
+});
+mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.1.0/mapbox-gl-rtl-text.js');
+map.addControl(new MapboxLanguage({
+  defaultLanguage: 'zh-Hans'
+}));
+</script>
+
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function MapboxLanguage(options) {
     }
   };
   this._excludedLayerIds = options.excludedLayerIds || [];
-  this.supportedLanguages = options.supportedLanguages || ['ar', 'en', 'es', 'fr', 'de', 'ja', 'ko', 'pt', 'ru', 'zh'];
+  this.supportedLanguages = options.supportedLanguages || ['ar', 'en', 'es', 'fr', 'de', 'ja', 'ko', 'pt', 'ru', 'zh', 'zh-Hans'];
 }
 
 function standardSpacing(style) {

--- a/index.js
+++ b/index.js
@@ -143,6 +143,9 @@ function adaptPropertyLanguage(isLangField, property, languageFieldName) {
 
 function changeLayerTextProperty(isLangField, layer, languageFieldName, excludedLayerIds) {
   if (layer.layout && layer.layout['text-field'] && excludedLayerIds.indexOf(layer.id) === -1) {
+    if (languageFieldName === 'zh-Hans' && ['country_label', 'state_label', 'marine_label'].indexOf(layer['source-layer']) !== -1) {
+      languageFieldName = 'zh';
+    }
     return Object.assign({}, layer, {
       layout: Object.assign({}, layer.layout, {
         'text-field': adaptPropertyLanguage(isLangField, layer.layout['text-field'], languageFieldName)

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var localeUtils = require('@mapbox/locale-utils');
+
 /**
  * Create a new [Mapbox GL JS plugin](https://www.mapbox.com/blog/build-mapbox-gl-js-plugins/) that
  * modifies the layers of the map style to use the 'text-field' that matches the browser language.
@@ -195,15 +197,7 @@ MapboxLanguage.prototype._initialStyleUpdate = function () {
 
 function browserLanguage(supportedLanguages) {
   var language = navigator.languages ? navigator.languages[0] : (navigator.language || navigator.userLanguage);
-  var parts = language.split('-');
-  var languageCode = language;
-  if (parts.length > 1) {
-    languageCode = parts[0];
-  }
-  if (supportedLanguages.indexOf(languageCode) > -1) {
-    return languageCode;
-  }
-  return null;
+  return localeUtils.bestMatchingLocale(language, supportedLanguages);
 }
 
 MapboxLanguage.prototype.onAdd = function (map) {

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
         2
       ]
     }
+  },
+  "dependencies": {
+    "@mapbox/locale-utils": "0.0.6"
   }
 }


### PR DESCRIPTION
This PR adds support for Simplified Chinese, falling back on Chinese for certain low-zoom-level source layers that lack Simplified Chinese data in Streets source v7.

locale-utils has been added as a dependency. This library is used for locale code matching in various other Mapbox tools, so using it here ensures consistent behavior. As this is the library’s first dependency, its inclusion breaks the normal `<script>` tag usage that the examples rely on. A build step will need to be added to build a version of the library that the examples can include direclty.

Additionally, a special case may need to be added for `mul`, as described in https://github.com/mapbox/mapbox-gl-language/pull/17#discussion_r199917148. locale-utils only supports valid IETF language tags, so supporting that PR’s `local` code would be less straightforward.

Fixes #5.

/cc @lukasmartinelli @bsudekum @chriswu42