### PR TITLE
ensure style is updated when control is added after the style is already loaded

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,11 @@ function browserLanguage(supportedLanguages) {
 
 MapboxLanguage.prototype.onAdd = function (map) {
   this._map = map;
-  this._map.on('style.load', this._initialStyleUpdate);
+  if (this._map.style && this._map.style._loaded) {
+    this._initialStyleUpdate();
+  } else {
+    this._map.on('style.load', this._initialStyleUpdate);
+  }
   this._container = document.createElement('div');
   return this._container;
 };


### PR DESCRIPTION
`map.on('style.load')` is only called if registered before the style resource has loaded, so in the case that the control is added to the map after the style resource has already loaded it won't trigger. Therefore within control `onAdd` we should check if the map style resource is already loaded and if so immediately trigger the `initialStyleUpdate`.