### PR TITLE
Handle alternate locale names, long locale names

### DIFF
--- a/examples/zh-HK.html
+++ b/examples/zh-HK.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang='zh-HK'>
+<head>
+    <meta charset='utf-8' />
+    <title>Mapbox GL Language</title>
+    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v2.4.0/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v2.4.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='../index.js'></script>
+    <style>
+        body { margin:0; padding:0; }
+        #map { position:absolute; top:0; bottom:0; width:100%; }
+    </style>
+</head>
+<body lang='zh-HK'>
+
+<div id='map'></div>
+<script>
+mapboxgl.accessToken = 'pk.eyJ1IjoibHVrYXNtYXJ0aW5lbGxpIiwiYSI6ImNpem85dmhwazAyajIyd284dGxhN2VxYnYifQ.HQCmyhEXZUTz3S98FMrVAQ';
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/streets-v11',
+    center: [114.3, 22.3],
+    minZoom: 2,
+    zoom: 9,
+    language: 'zh-HK',
+});
+mapboxgl.setRTLTextPlugin('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js');
+map.addControl(new MapboxLanguage({
+  defaultLanguage: 'zh-HK'
+}));
+</script>
+
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /* accept values from common locale selectors */
-const SYNONYMS = {
+const ALT_LOCALES = {
   'zh-CN': 'zh-Hans',
   'zh-Hans-CN': 'zh-Hans',
   'zh-HK': 'zh-Hant',
@@ -125,7 +125,7 @@ function findStreetsSource(style) {
  * @returns {object} the modified style
  */
 MapboxLanguage.prototype.setLanguage = function (style, language) {
-  language = SYNONYMS[language] || language;
+  language = ALT_LOCALES[language] || language;
   if (this.supportedLanguages.indexOf(language) < 0) {
     throw new Error(`Language ${  language  } is not supported`);
   }
@@ -156,7 +156,7 @@ MapboxLanguage.prototype._initialStyleUpdate = function () {
 
 function browserLanguage(supportedLanguages) {
   let language = navigator.languages ? navigator.languages[0] : (navigator.language || navigator.userLanguage);
-  language = SYNONYMS[language] || language;
+  language = ALT_LOCALES[language] || language;
   const parts = language && language.split('-');
   let languageCode = language;
   if (parts.length > 1) {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,13 @@
+/* accept values from common locale selectors */
+const SYNONYMS = {
+  'zh-CN': 'zh-Hans',
+  'zh-Hans-CN': 'zh-Hans',
+  'zh-HK': 'zh-Hant',
+  'zh-Hant-HK': 'zh-Hant',
+  'zh-TW': 'zh-Hant',
+  'zh-Hant-TW': 'zh-Hant',
+};
+
 /**
  * Create a new [Mapbox GL JS plugin](https://www.mapbox.com/blog/build-mapbox-gl-js-plugins/) that
  * modifies the layers of the map style to use the `text-field` that matches the browser language.
@@ -115,7 +125,10 @@ function findStreetsSource(style) {
  * @returns {object} the modified style
  */
 MapboxLanguage.prototype.setLanguage = function (style, language) {
-  if (this.supportedLanguages.indexOf(language) < 0) throw new Error(`Language ${  language  } is not supported`);
+  language = SYNONYMS[language] || language;
+  if (this.supportedLanguages.indexOf(language) < 0) {
+    throw new Error(`Language ${  language  } is not supported`);
+  }
   const streetsSource = this._languageSource || findStreetsSource(style);
   if (!streetsSource) return style;
 
@@ -142,7 +155,8 @@ MapboxLanguage.prototype._initialStyleUpdate = function () {
 };
 
 function browserLanguage(supportedLanguages) {
-  const language = navigator.languages ? navigator.languages[0] : (navigator.language || navigator.userLanguage);
+  let language = navigator.languages ? navigator.languages[0] : (navigator.language || navigator.userLanguage);
+  language = SYNONYMS[language] || language;
   const parts = language && language.split('-');
   let languageCode = language;
   if (parts.length > 1) {


### PR DESCRIPTION
As described in #66 , there are multiple ways to write Chinese-language locales and they are getting reduced to `zh` by `setLanguage` and `browserLanguage` functions

My proposal is:
- Using `ALT_LOCALES`, locales such as `zh-HK` will be handled as OSM and Mapbox's supported locale `zh-Hant`
- Use recursion to remove locales piece by piece, for example `zh-Hans-CN` should be reduced to `zh-Hans` first and not a one time split to `zh`
- Add a `zh-HK` example page